### PR TITLE
Add example CR that allocates existing EIPs from a pool in DynamoDB

### DIFF
--- a/examples/eip-lookup/README.md
+++ b/examples/eip-lookup/README.md
@@ -1,0 +1,6 @@
+# EIP Lookup Custom Resource
+This custom resource returns a pre-provisioned Elastic IP address that is stored in a DynamoDB table. It addresses the scenario where an EC2 instance needs a known EIP, usually because the address has been white-listed with a 3rd party.  This resource supports associating an EIP with a pool. For example, you might have a default pool of EIPs, and another pool used for interacting with a specific 3rd party API.
+
+EIPs and their pool association are stored in DynamoDB. An example DynamoDB table is provisioned by`impl/custom-resource-runner.template`.  The table schema designates the EIP pool name as the Hash Key, and the EIP address as the Range Key, allowing all addresses in a given pool to be efficiently retrieved. The custom resource uses consistent reads and conditional updates to ensure consistency, and supports updating the pool name of a resource.
+
+Although the above template provisions the required DynamoDB table to store EIPs and their pools, you must populate the table with values for existing EIP addresses. Use _default_ for the pool name if you do not require pooling.

--- a/examples/eip-lookup/example.template
+++ b/examples/eip-lookup/example.template
@@ -1,0 +1,61 @@
+{
+    "AWSTemplateFormatVersion" : "2010-09-09",
+
+    "Description" : "An example of the EIP Lookup custom resource",
+
+    "Parameters" : {
+        "InstanceType" : {
+            "Description" : "Example instance types",
+            "Type" : "String",
+            "Default" : "t1.micro",
+            "AllowedValues" : [ "t1.micro","m1.small","m1.medium","m1.large","m1.xlarge","m2.xlarge","m2.2xlarge","m2.4xlarge","m3.xlarge","m3.2xlarge","c1.medium","c1.xlarge","cc1.4xlarge","cc2.8xlarge","cg1.4xlarge"],
+            "ConstraintDescription" : "must be a valid EC2 instance type."
+        },
+        "EipLookupServiceToken" : {
+            "Description" : "ServiceToken of EIP Lookup Custom Resource",
+            "Type" : "String",
+            "AllowedPattern" : "arn:aws:sns:.*",
+            "ConstraintDescription" : "must be an SNS topic ARN"
+        }
+    },
+
+    "Mappings" : {
+        "RegionMap" : {
+          "us-east-1"      : { "AMI" : "ami-7f418316" },
+          "us-west-1"      : { "AMI" : "ami-951945d0" },
+          "us-west-2"      : { "AMI" : "ami-16fd7026" },
+          "eu-west-1"      : { "AMI" : "ami-24506250" },
+          "sa-east-1"      : { "AMI" : "ami-3e3be423" },
+          "ap-southeast-1" : { "AMI" : "ami-74dda626" },
+          "ap-southeast-2" : { "AMI" : "ami-b3990e89" },
+          "ap-northeast-1" : { "AMI" : "ami-dcfa4edd" }
+        }
+  },
+
+  "Resources" : {
+    "Ec2Instance" : {
+      "Type" : "AWS::EC2::Instance",
+      "Properties" : {
+        "UserData" : { "Fn::Base64" : { "Fn::Join" : [ "", [ "IPAddress=", {"Ref" : "IPAddress"}]]}},
+        "ImageId" : { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "AMI" ]}
+      }
+    },
+
+    "IPAddress" : {
+        "Type" : "Custom::EipLookup",
+        "Version" : "1.0",
+        "Properties" : {
+            "ServiceToken" : { "Ref" : "EipLookupServiceToken" },
+            "pool" : "default"
+        }
+    },
+
+    "IPAssoc" : {
+      "Type" : "AWS::EC2::EIPAssociation",
+      "Properties" : {
+        "InstanceId" : { "Ref" : "Ec2Instance" },
+        "EIP" : { "Ref" : "IPAddress" }
+      }
+    }
+  }
+}

--- a/examples/eip-lookup/impl/custom-resource-runner.template
+++ b/examples/eip-lookup/impl/custom-resource-runner.template
@@ -1,0 +1,236 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description" : "Example stack for EIP Lookup Custom Resource Backend.",
+
+    "Parameters" : {
+        "KeyName" : {
+            "Description" : "Name of an existing EC2 KeyPair to enable SSH access to the instances",
+            "Type" : "String"
+        },
+        "InstanceType" : {
+            "Description" : "Custom resource runner instance type",
+            "Type" : "String",
+            "Default" : "t1.micro",
+            "AllowedValues" : [ "t1.micro","m1.small","m1.medium","m1.large","m1.xlarge","m2.xlarge","m2.2xlarge","m2.4xlarge","m3.xlarge","m3.2xlarge","c1.medium","c1.xlarge","cc1.4xlarge","cc2.8xlarge","cg1.4xlarge"],
+            "ConstraintDescription" : "must be a valid EC2 instance type."
+        },
+        "MinSize" : {
+            "Description" : "Minimum number of custom resource runners",
+            "Type" : "Number",
+            "MinValue" : "1",
+            "Default" : "1",
+            "ConstraintDescription" : "Must have at least one runner"
+        },
+        "MaxSize" : {
+            "Description" : "Maximum number of custom resource runners",
+            "Type" : "Number",
+            "MinValue" : "1",
+            "Default" : "1",
+            "ConstraintDescription" : "Must have at least one runner"
+        },
+        "SSHLocation" : {
+            "Description" : "The IP address range that can be used to SSH to the custom resource runners",
+            "Type" : "String",
+            "MinLength" : "9",
+            "MaxLength" : "18",
+            "Default" : "0.0.0.0/0",
+            "AllowedPattern" : "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+            "ConstraintDescription" : "must be a valid IP CIDR range of the form x.x.x.x/x."
+        }
+    },
+
+    "Mappings" : {
+        "AwsRegionToAMI" : {
+            "us-east-1" : { "id" : "ami-35792c5c" },
+            "us-west-2" : { "id" : "ami-d03ea1e0" },
+            "us-west-1" : { "id" : "ami-687b4f2d" },
+            "eu-west-1" : { "id" : "ami-149f7863" },
+            "ap-southeast-1" : { "id" : "ami-14f2b946" },
+            "ap-northeast-1" : { "id" : "ami-3561fe34" },
+            "ap-southeast-2" : { "id" : "ami-a148d59b" },
+            "sa-east-1" : { "id" : "ami-9f6ec982" }
+        }
+    },
+
+    "Resources" : {
+        "CustomResourcePipeline" : {
+            "Type" : "AWS::CloudFormation::Stack",
+            "Properties" : {
+                "TemplateURL" : "https://s3.amazonaws.com/cloudformation-examples/cr-backend-substack-template.template"
+            }
+        },
+
+        "EipTable" : {
+            "Type" : "AWS::DynamoDB::Table",
+            "Properties" : {
+                "KeySchema" : {
+                    "HashKeyElement": {
+                        "AttributeName" : "pool",
+                        "AttributeType" : "S"
+                    },
+                    "RangeKeyElement" : {
+                        "AttributeName" : "address",
+                        "AttributeType" : "S"
+                    }
+                },
+                "ProvisionedThroughput" : {
+                    "ReadCapacityUnits" : "1",
+                    "WriteCapacityUnits" : "3"
+                }
+            }
+        },
+
+        "RunnerRole" : {
+            "Type" : "AWS::IAM::Role",
+            "Properties" : {
+                "AssumeRolePolicyDocument" : {
+                    "Version": "2008-10-17",
+                    "Statement": [{
+                        "Effect": "Allow",
+                        "Principal": {
+                            "Service": [ "ec2.amazonaws.com" ]
+                        },
+                        "Action": [ "sts:AssumeRole" ]
+                    }]
+                },
+                "Path" : "/",
+                "Policies" : [
+                    {
+                        "PolicyName" : "CustomResourceRunner",
+                        "PolicyDocument" : {
+                            "Statement" : [
+                                {
+                                    "Effect" : "Allow",
+                                    "Action" : ["sqs:ChangeMessageVisibility", "sqs:DeleteMessage", "sqs:ReceiveMessage"],
+                                    "Resource" : { "Fn::GetAtt" : ["CustomResourcePipeline", "Outputs.CustomResourceQueueARN"] }
+                                },
+                                {
+                                    "Effect" : "Allow",
+                                    "Action" : ["dynamodb:PutItem"],
+                                    "Resource" : { "Fn::Join" : ["", ["arn:aws:dynamodb:", {"Ref" : "AWS::Region"}, ":*:table/", { "Ref" : "EipTable" }]] }
+                                },
+                                {
+                                    "Effect" : "Allow",
+                                    "Action" : ["dynamodb:Query"],
+                                    "Resource" : { "Fn::Join" : ["", ["arn:aws:dynamodb:", {"Ref" : "AWS::Region"}, ":*:table/", { "Ref" : "EipTable" }]] }
+                                },
+                                {
+                                    "Effect" : "Allow",
+                                    "Action" : ["dynamodb:GetItem"],
+                                    "Resource" : { "Fn::Join" : ["", ["arn:aws:dynamodb:", {"Ref" : "AWS::Region"}, ":*:table/", { "Ref" : "EipTable" }]] }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+
+        "RunnerInstanceProfile" : {
+            "Type" : "AWS::IAM::InstanceProfile",
+            "Properties" : {
+                "Path" : "/",
+                "Roles" : [ { "Ref" : "RunnerRole" } ]
+            }
+        },
+
+        "RunnerLaunchConfig" : {
+            "Type" : "AWS::AutoScaling::LaunchConfiguration",
+            "Properties" : {
+                "IamInstanceProfile" : { "Ref" : "RunnerInstanceProfile" },
+                "ImageId" : { "Fn::FindInMap" : ["AwsRegionToAMI", { "Ref" : "AWS::Region" }, "id"] },
+                "InstanceType" : { "Ref" : "InstanceType" },
+                "KeyName" : { "Ref" : "KeyName" },
+                "SecurityGroups" : [ { "Ref" : "RunnerSecurityGroup" } ],
+                "UserData" : { "Fn::Base64" : { "Fn::Join" : ["", [
+                    "#!/bin/bash -x\n",
+                    "exec &> /home/ec2-user/userdata.log\n",
+                    "/opt/aws/bin/cfn-init --region ", { "Ref" : "AWS::Region" }, " -s ", { "Ref" : "AWS::StackId" }, " -r RunnerLaunchConfig -v\n",
+                    "/opt/aws/bin/cfn-signal -e $? ", { "Fn::Base64" : { "Ref" : "RunnerWaitConditionHandle" }}, "\n"
+                ]] } }
+            },
+            "Metadata" : {
+                "AWS::CloudFormation::Init" : {
+                    "config" : {
+                        "packages" : {
+                            "rpm" : {
+                                "aws-cfn-resource-bridge" : "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-resource-bridge-0.1-4.noarch.rpm"
+                            }
+                        },
+                        "files" : {
+                            "/etc/cfn/bridge.d/eip-lookup.conf" : {
+                                "content" : { "Fn::Join" : ["", [
+                                    "[eip-lookup]\n",
+                                    "resource_type=Custom::EipLookup\n",
+                                    "queue_url=", { "Fn::GetAtt" : ["CustomResourcePipeline", "Outputs.CustomResourceQueueURL"] }, "\n",
+                                    "timeout=60\n",
+                                    "default_action=/home/ec2-user/lookup-eip.py -r ", { "Ref" : "AWS::Region" }, " -t ", { "Ref" : "EipTable" }
+                                ]]}
+                            },
+                            "/home/ec2-user/lookup-eip.py" : {
+                                "source" : "https://raw.github.com/awslabs/aws-cfn-custom-resource-examples/master/examples/eip-lookup/impl/lookup-eip.py",
+                                "mode" : "000755",
+                                "owner" : "ec2-user"
+                            }
+                        },
+                        "services" : {
+                            "sysvinit" : {
+                                "cfn-resource-bridge" : {
+                                    "enabled" : "true",
+                                    "ensureRunning" : "true",
+                                    "files" : ["/etc/cfn/bridge.d/eip-lookup.conf",
+                                               "/home/ec2-user/lookup-eip.py"]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+
+        "RunnerAutoScalingGroup" : {
+            "Type" : "AWS::AutoScaling::AutoScalingGroup",
+            "Properties" : {
+                "AvailabilityZones" : { "Fn::GetAZs" : ""},
+                "LaunchConfigurationName" : { "Ref" : "RunnerLaunchConfig" },
+                "MinSize" : { "Ref" : "MinSize" },
+                "MaxSize" : { "Ref" : "MaxSize" }
+            }
+        },
+
+        "RunnerSecurityGroup" : {
+            "Type" : "AWS::EC2::SecurityGroup",
+            "Properties" : {
+                "GroupDescription" : "SSH to the runner instances",
+                "SecurityGroupIngress" : [
+                    {
+                        "CidrIp" : { "Ref" : "SSHLocation" },
+                        "FromPort" : "22",
+                        "ToPort" : "22",
+                        "IpProtocol" : "tcp"
+                    }
+                ]
+            }
+        },
+
+        "RunnerWaitConditionHandle" : {
+            "Type" : "AWS::CloudFormation::WaitConditionHandle"
+        },
+
+        "RunnerWaitCondition" : {
+            "Type" : "AWS::CloudFormation::WaitCondition",
+            "DependsOn" : "RunnerAutoScalingGroup",
+            "Properties" : {
+                "Count" : "1",
+                "Handle" : { "Ref" : "RunnerWaitConditionHandle" },
+                "Timeout" : "600"
+            }
+        }
+    },
+    "Outputs" : {
+        "ServiceToken" : {
+            "Value" : { "Fn::GetAtt" : ["CustomResourcePipeline", "Outputs.CustomResourceTopicARN"] },
+            "Description" : "Service token to use in CustomResource definitions"
+        }
+    }
+}

--- a/examples/eip-lookup/impl/custom-resource-runner.template
+++ b/examples/eip-lookup/impl/custom-resource-runner.template
@@ -36,6 +36,11 @@
             "Default" : "0.0.0.0/0",
             "AllowedPattern" : "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
             "ConstraintDescription" : "must be a valid IP CIDR range of the form x.x.x.x/x."
+        },
+        "LookupEipScriptUrl" : {
+            "Description" : "The URL of the lookup-eip.py script",
+            "Type" : "String",
+            "Default" : "https://raw.github.com/awslabs/aws-cfn-custom-resource-examples/master/examples/eip-lookup/impl/lookup-eip.py"
         }
     },
 
@@ -107,17 +112,17 @@
                                 {
                                     "Effect" : "Allow",
                                     "Action" : ["dynamodb:PutItem"],
-                                    "Resource" : { "Fn::Join" : ["", ["arn:aws:dynamodb:", {"Ref" : "AWS::Region"}, ":*:table/", { "Ref" : "EipTable" }]] }
+                                    "Resource" : { "Fn::Join" : ["", ["arn:aws:dynamodb:", {"Ref" : "AWS::Region"}, ":", {"Ref" : "AWS::AccountId"}, ":table/", { "Ref" : "EipTable" }]] }
                                 },
                                 {
                                     "Effect" : "Allow",
                                     "Action" : ["dynamodb:Query"],
-                                    "Resource" : { "Fn::Join" : ["", ["arn:aws:dynamodb:", {"Ref" : "AWS::Region"}, ":*:table/", { "Ref" : "EipTable" }]] }
+                                    "Resource" : { "Fn::Join" : ["", ["arn:aws:dynamodb:", {"Ref" : "AWS::Region"}, ":", {"Ref" : "AWS::AccountId"}, ":table/", { "Ref" : "EipTable" }]] }
                                 },
                                 {
                                     "Effect" : "Allow",
                                     "Action" : ["dynamodb:GetItem"],
-                                    "Resource" : { "Fn::Join" : ["", ["arn:aws:dynamodb:", {"Ref" : "AWS::Region"}, ":*:table/", { "Ref" : "EipTable" }]] }
+                                    "Resource" : { "Fn::Join" : ["", ["arn:aws:dynamodb:", {"Ref" : "AWS::Region"}, ":", {"Ref" : "AWS::AccountId"}, ":table/", { "Ref" : "EipTable" }]] }
                                 }
                             ]
                         }
@@ -168,7 +173,7 @@
                                 ]]}
                             },
                             "/home/ec2-user/lookup-eip.py" : {
-                                "source" : "https://raw.github.com/awslabs/aws-cfn-custom-resource-examples/master/examples/eip-lookup/impl/lookup-eip.py",
+                                "source" : { "Ref" : "LookupEipScriptUrl" },
                                 "mode" : "000755",
                                 "owner" : "ec2-user"
                             }

--- a/examples/eip-lookup/impl/lookup-eip.py
+++ b/examples/eip-lookup/impl/lookup-eip.py
@@ -47,20 +47,10 @@ class FatalError(SystemExit):
 if not options.region or not options.table_name:
     raise FatalError(u"Service not configured to handle requests.")
 
-# Get the request type for this
+# Get the Request Type, Stack ID, and Logical Resource ID
 request_type = os.getenv('Event_RequestType')
-if not request_type:
-    raise FatalError(u"Event_RequestType was not valid.")
-
-# Get Stack ID
 stack_id = os.getenv('Event_StackId')
-if not stack_id:
-    raise FatalError(u"Event_StackId is a required attribute.")
-
-# Get Logical ID of this resource
 logical_id = os.getenv('Event_LogicalResourceId')
-if not logical_id:
-    raise FatalError(u"Event_LogicalResourceId is a required attribute.")
 
 # Get pool indicating where to get EIP from
 pool = os.getenv('Event_ResourceProperties_pool', 'default')
@@ -116,8 +106,6 @@ elif request_type == 'Update':
 
     # If the updated resource wants an EIP from a different pool
     if not pool == old_pool:
-        # Release the old address
-        delete_address(old_pool, old_address)
 
         # And get a new one
         physical_id = get_address(pool)

--- a/examples/eip-lookup/impl/lookup-eip.py
+++ b/examples/eip-lookup/impl/lookup-eip.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+#==============================================================================
+# Copyright 2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#==============================================================================
+import os
+import sys
+import logging
+from argparse import ArgumentParser
+
+import boto
+from boto.dynamodb2.table import Table
+
+
+handler = logging.StreamHandler(sys.stderr)
+handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
+logging.getLogger().addHandler(handler)
+
+log = logging.getLogger('lookup-eip')
+log.setLevel(logging.INFO)
+
+parser = ArgumentParser(prog='lookup-eip')
+parser.add_argument("-r", "--region", help="The region the audit trail will be written to in DynamoDB", dest="region")
+parser.add_argument("-t", "--eip-table", help="The DynamoDB table that lists available EIPs", dest="table_name")
+
+options = parser.parse_args()
+
+
+class FatalError(SystemExit):
+    def __init__(self, reason):
+        super(FatalError, self).__init__(-1)
+        log.error('Failing resource: %s', reason)
+        print u'{ "Reason": "%s" }' % reason
+
+# Get Region
+if not options.region or not options.table_name:
+    raise FatalError(u"Service not configured to handle requests.")
+
+# Get the request type for this
+request_type = os.getenv('Event_RequestType')
+if not request_type:
+    raise FatalError(u"Event_RequestType was not valid.")
+
+# Get Stack ID
+stack_id = os.getenv('Event_StackId')
+if not stack_id:
+    raise FatalError(u"Event_StackId is a required attribute.")
+
+# Get Logical ID of this resource
+logical_id = os.getenv('Event_LogicalResourceId')
+if not logical_id:
+    raise FatalError(u"Event_LogicalResourceId is a required attribute.")
+
+# Get pool indicating where to get EIP from
+pool = os.getenv('Event_ResourceProperties_pool', 'default')
+
+
+def get_address(pool):
+    """Retrieve an EIP for the given pool from DynamoDB"""
+    #Connect to ddb
+    conn = boto.dynamodb2.connect_to_region(options.region)
+    ddb = Table(options.table_name, connection=conn)
+
+    # Get available EIPs from pool
+    eips = ddb.query(
+        pool__eq=pool,
+        consistent=True
+    )
+
+    if not eips:
+        raise FatalError(u"No EIPs found in pool %s" % pool)
+
+    address = None
+    for eip in eips:
+        if not eip.get('stack_id', False):
+            eip['stack_id'] = stack_id
+            eip['logical_id'] = logical_id
+            if eip.save():
+                address = eip['address']
+                break
+
+    if not address:
+        raise FatalError(u"All EIPs in pool %s are in use" % pool)
+
+    return address
+
+
+def delete_address(pool, address):
+    """Mark an EIP as no longer in use"""
+    #Connect to ddb
+    conn = boto.dynamodb2.connect_to_region(options.region)
+    ddb = Table(options.table_name, connection=conn)
+
+    eip = ddb.get_item(pool=pool, address=address)
+    del eip['stack_id']
+    del eip['logical_id']
+    eip.save()
+
+if request_type == 'Create':
+    physical_id = get_address(pool)
+
+elif request_type == 'Update':
+    old_pool = os.getenv('Event_OldResourceProperties_pool', 'default')
+    old_address = os.getenv('Event_PhysicalResourceId')
+
+    # If the updated resource wants an EIP from a different pool
+    if not pool == old_pool:
+        # Release the old address
+        delete_address(old_pool, old_address)
+
+        # And get a new one
+        physical_id = get_address(pool)
+    else:
+        physical_id = old_address
+
+elif request_type == 'Delete':
+    address = os.getenv('Event_PhysicalResourceId')
+
+    delete_address(pool, address)
+
+# Write out our successful response!
+if request_type != 'Delete':
+    print u'{ "PhysicalResourceId" : "%s" }' % physical_id
+else:
+    print u"{}"

--- a/examples/eip-lookup/impl/lookup-eip.py
+++ b/examples/eip-lookup/impl/lookup-eip.py
@@ -106,7 +106,6 @@ elif request_type == 'Update':
 
     # If the updated resource wants an EIP from a different pool
     if not pool == old_pool:
-
         # And get a new one
         physical_id = get_address(pool)
     else:
@@ -114,7 +113,6 @@ elif request_type == 'Update':
 
 elif request_type == 'Delete':
     address = os.getenv('Event_PhysicalResourceId')
-
     delete_address(pool, address)
 
 # Write out our successful response!


### PR DESCRIPTION
This example CR queries DynamoDB for available, pre-provisioned EIPs and returns the first unassigned address. Addresses are grouped into named pools, where pool name is the DDB HK and EIP addr is the DDB RK. The CR handles Create, Update, and Delete.
